### PR TITLE
feat: remove node_down metric, and report node as unhealthy instead

### DIFF
--- a/prometheus/collectors/desc.go
+++ b/prometheus/collectors/desc.go
@@ -22,10 +22,6 @@ var desc = struct {
 		blockExplorerInfo *prometheus.Desc
 	}
 
-	NodeDown struct {
-		nodeDown *prometheus.Desc
-	}
-
 	MetaMonitoring struct {
 		monitoringDatabaseHealthy *prometheus.Desc
 	}
@@ -72,13 +68,6 @@ func init() {
 	//
 	desc.BlockExplorer.blockExplorerInfo = prometheus.NewDesc(
 		"blockexplorer_info", "Basic information about block explorer", []string{"node", "type", "environment", "internal", "version", "version_hash"}, nil,
-	)
-
-	//
-	// Node Down
-	//
-	desc.NodeDown.nodeDown = prometheus.NewDesc(
-		"node_down", "Node is not responsive", []string{"node", "type", "environment", "internal"}, nil,
 	)
 
 	//

--- a/prometheus/nodescanner/core_stats.go
+++ b/prometheus/nodescanner/core_stats.go
@@ -79,3 +79,14 @@ func requestCoreStats(address string, headers []string) (*types.CoreStatus, map[
 		headerValues,
 		nil
 }
+
+func getUnhealthyCoreStats() *types.CoreStatus {
+	return &types.CoreStatus{
+		CurrentTime:        time.Now().UTC(),
+		CoreTime:           time.Unix(0, 0),
+		CoreBlockHeight:    0,
+		CoreChainId:        "",
+		CoreAppVersion:     "",
+		CoreAppVersionHash: "",
+	}
+}

--- a/prometheus/nodescanner/datanode_stats.go
+++ b/prometheus/nodescanner/datanode_stats.go
@@ -42,3 +42,11 @@ func requestDataNodeStats(address string) (*types.DataNodeStatus, error) {
 		DataNodeBlockHeight: dataNodeBlockHeight,
 	}, nil
 }
+
+func getUnhealthyDataNodeStats() *types.DataNodeStatus {
+	return &types.DataNodeStatus{
+		CoreStatus:          *getUnhealthyCoreStats(),
+		DataNodeTime:        time.Unix(0, 0),
+		DataNodeBlockHeight: 0,
+	}
+}

--- a/prometheus/nodescanner/explorer_stats.go
+++ b/prometheus/nodescanner/explorer_stats.go
@@ -54,3 +54,11 @@ func requestBlockExplorerStats(address string) (*types.BlockExplorerStatus, erro
 		BlockExplorerVersionHash: payload.VersionHash,
 	}, nil
 }
+
+func getUnhealthyBlockExplorerStats() *types.BlockExplorerStatus {
+	return &types.BlockExplorerStatus{
+		CoreStatus:               *getUnhealthyCoreStats(),
+		BlockExplorerVersion:     "",
+		BlockExplorerVersionHash: "",
+	}
+}


### PR DESCRIPTION
There are two problems with the node_down metric:
1. It isn't very clear to people
2. PromQL has problems with merging it with other metrics
Replacing it with regular metrics, but with unhealthy values should solve both of the issues