### PR TITLE
feat: implement health-check for vega-monitoring

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -232,6 +232,10 @@ func NewDefaultConfig() Config {
 	config.DataNodeDBExtension.NetworkBalances.Enabled = true
 	config.DataNodeDBExtension.AssetPrices.Enabled = true
 	config.DataNodeDBExtension.BaseRetentionPolicy = DefaultRetentionPolicy
+	// HealthCheck
+	config.HealthCheck.Enabled = true
+	config.HealthCheck.Port = 8901
+	config.HealthCheck.GrafanaServer.Enabled = false
 
 	return config
 }

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,8 @@ type Config struct {
 
 	Ethereum EthereumConfig `group:"Ethereum" namespace:"ethereum"`
 
+	HealthCheck HealthCheckConfig `group:"HealthCheck" namespace:"healthcheck"`
+
 	Logging struct {
 		Level string `long:"Level"`
 	} `group:"Logging" namespace:"logging"`
@@ -35,6 +37,15 @@ type Config struct {
 	Monitoring MonitoringConfig `group:"Monitoring" namespace:"monitoring" comment:"collected metrics are exposed on prometheus"`
 
 	DataNodeDBExtension DataNodeDBExtensionConfig `group:"DataNodeDBExtension" namespace:"datanodedbextension" comment:"Create extra tables in DataNode database, and continuously fill them in"`
+}
+
+type HealthCheckConfig struct {
+	Enabled       bool
+	Port          int `long:"port" comment:"the port health-check HTTP server is running on"`
+	GrafanaServer struct {
+		Enabled bool `long:"enabled" comment:"if enabled, the health-check expects grafana-server to be running"`
+		Port    int  `long:"port" comment:"port the grafana-server is running on"`
+	} `group:"GrafanaServer" namespace:"grafanaserver"`
 }
 
 type CoingeckoConfig struct {

--- a/entities/metamonitoring_check.go
+++ b/entities/metamonitoring_check.go
@@ -48,6 +48,12 @@ func (s MonitoringStatus) UnhealthyReasonString() string {
 }
 
 func UnHealthyReasonString(reason UnhealthyReason) string {
+	switch reason {
+	case ReasonMissingStatusFromService:
+		return "Missing status from the service"
+	case ReasonNetworkIsNotUpToDate:
+		return "Network is not up to date"
+	}
 
 	return "Unknown reason"
 }

--- a/metamonitoring/health_check.go
+++ b/metamonitoring/health_check.go
@@ -1,0 +1,119 @@
+package metamonitoring
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"code.vegaprotocol.io/vega/logging"
+	"github.com/google/uuid"
+	"github.com/vegaprotocol/vega-monitoring/services/read"
+	"go.uber.org/zap"
+)
+
+const responseCacheTime = 30 * time.Second
+
+type readService interface {
+	GetMetaMonitoringStatusesExtended(context.Context) (read.MetaMonitoringStatusesExtended, error)
+}
+
+type healthCheckResponse struct {
+	Healthy bool
+	Details read.MetaMonitoringStatusesExtended
+}
+
+type HealthCheckService struct {
+	readService  readService
+	mut          sync.Mutex
+	cachedAt     time.Time
+	lastResponse *healthCheckResponse
+	logger       *logging.Logger
+}
+
+func NewHealthCheckService(readService readService, logger *logging.Logger) (*HealthCheckService, error) {
+	return &HealthCheckService{
+		readService: readService,
+		logger:      logger,
+		cachedAt:    time.Unix(0, 0),
+	}, nil
+}
+
+func (hc *HealthCheckService) fetchStatus(ctx context.Context) (*healthCheckResponse, error) {
+	statuses, err := hc.readService.GetMetaMonitoringStatusesExtended(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch latest monitoring statuses: %w", err)
+	}
+
+	return &healthCheckResponse{
+		Healthy: statuses.HealthyOverAll,
+		Details: statuses,
+	}, nil
+}
+
+func (hc *HealthCheckService) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		hc.mut.Lock()
+		defer hc.mut.Unlock()
+		requestId := uuid.New().String()
+
+		now := time.Now()
+		var err error
+		if hc.lastResponse == nil || now.Sub(hc.cachedAt) >= responseCacheTime {
+			hc.lastResponse, err = hc.fetchStatus(context.Background())
+			if err != nil {
+				hc.logger.Error("Failed to fetch monitoring status", zap.Error(err), zap.String("requestId", requestId))
+				w.Write([]byte(fmt.Sprintf("Internal server error (request %s)", requestId)))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+
+		response, err := json.MarshalIndent(hc.lastResponse, "", "    ")
+		if err != nil {
+			hc.logger.Error("Failed to marshal response", zap.Error(err), zap.String("requestId", requestId))
+			w.Write([]byte(fmt.Sprintf("Internal server error (request %s)", requestId)))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Write(response)
+		if hc.lastResponse.Details.HealthyOverAll {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (hc *HealthCheckService) Run(ctx context.Context, port int) error {
+	srv := &http.Server{
+		Addr:           fmt.Sprintf(":%d", port),
+		Handler:        hc.handler(),
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+
+	go func(server *http.Server) {
+		hc.logger.Infof("Starting server at port %d", port)
+		err := server.ListenAndServe()
+		if errors.Is(err, http.ErrServerClosed) {
+			fmt.Printf("server closed\n")
+		} else if err != nil {
+			fmt.Printf("error starting server: %s\n", err)
+		}
+	}(srv)
+
+	time.Sleep(3 * time.Second)
+	<-ctx.Done()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	srv.Shutdown(shutdownCtx)
+
+	return nil
+}

--- a/metamonitoring/health_check.go
+++ b/metamonitoring/health_check.go
@@ -18,7 +18,7 @@ import (
 const responseCacheTime = 30 * time.Second
 
 type readService interface {
-	GetMetaMonitoringStatusesExtended(context.Context) (read.MetaMonitoringStatusesExtended, error)
+	GetMetaMonitoringStatusesExtended(context.Context) (*read.MetaMonitoringStatusesExtended, error)
 }
 
 type healthCheckResponse struct {
@@ -50,7 +50,7 @@ func (hc *HealthCheckService) fetchStatus(ctx context.Context) (*healthCheckResp
 
 	return &healthCheckResponse{
 		Healthy: statuses.HealthyOverAll,
-		Details: statuses,
+		Details: *statuses,
 	}, nil
 }
 


### PR DESCRIPTION
# Changes

The vega-monitoring tool has 5 main integrations/services
- asset prices from finance & etherscan API, 
- block signers, 
- commet txs 
- network balances 
- network history segments

At the moment, We do not have a metamonitoring that tells the load balancer that any of the services are unhealthy. It causes some issues some alerts are not working properly or some data in charts is missing.
This PR fixes the issue

# Testing

The change has been released yesterday.

![image](https://github.com/vegaprotocol/vega-monitoring/assets/1239637/d0b67804-4a85-4322-ba60-ab720ae6d177)
