### PR TITLE
feat: restrict blocks for comet txs flush

### DIFF
--- a/clients/comet/block_results.go
+++ b/clients/comet/block_results.go
@@ -105,7 +105,7 @@ func (c *CometClient) GetTxsForBlockRangeNotFiltered(fromBlock int64, toBlock in
 	for _, response := range responses {
 		txsList, err := parseBlockResultsResponse(response)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse block result response for block %d: %w", response.Result.Height, err)
+			return nil, fmt.Errorf("failed to parse block result response for block %s: %w", response.Result.Height, err)
 		}
 		result = append(result, txsList...)
 	}

--- a/clients/comet/block_results.go
+++ b/clients/comet/block_results.go
@@ -96,17 +96,16 @@ func (c *CometClient) GetTxsForBlockNotFiltered(block int64) ([]CometTx, error) 
 }
 
 func (c *CometClient) GetTxsForBlockRangeNotFiltered(fromBlock int64, toBlock int64) ([]CometTx, error) {
-
 	responses, err := c.requestBlockResultsRange(fromBlock, toBlock)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Block Result data for blocks from %d to %d, %w", fromBlock, toBlock, err)
+		return nil, fmt.Errorf("failed to get block result data for blocks from %d to %d, %w", fromBlock, toBlock, err)
 	}
 	result := []CometTx{}
 
 	for _, response := range responses {
 		txsList, err := parseBlockResultsResponse(response)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get Block Result data for blocks from %d to %d, %w", fromBlock, toBlock, err)
+			return nil, fmt.Errorf("failed to parse block result response for block %d: %w", response.Result.Height, err)
 		}
 		result = append(result, txsList...)
 	}

--- a/sqlstore/blocks.go
+++ b/sqlstore/blocks.go
@@ -40,6 +40,24 @@ func (b *Blocks) GetLastBlock(ctx context.Context) (*vega_entities.Block, error)
 	return block, nil
 }
 
+func (b *Blocks) GetLastBlockHeight(ctx context.Context) (*int64, error) {
+	blockHeight := int64(0)
+	if err := pgxscan.Get(ctx, b.Connection, &blockHeight, `SELECT MAX(height) FROM blocks`); err != nil {
+		return nil, fmt.Errorf("failed to get latest block height: %w", err)
+	}
+
+	return &blockHeight, nil
+}
+
+func (b *Blocks) GetEarliestBlockHeight(ctx context.Context) (*int64, error) {
+	blockHeight := int64(0)
+	if err := pgxscan.Get(ctx, b.Connection, &blockHeight, `SELECT MIN(height) FROM blocks`); err != nil {
+		return nil, fmt.Errorf("failed to get earliest block height: %w", err)
+	}
+
+	return &blockHeight, nil
+}
+
 func (b *Blocks) GetLatestBlockWithCache(ctx context.Context, cacheTime time.Duration) (*vega_entities.Block, error) {
 	b.lastBlockMutex.Lock()
 	defer b.lastBlockMutex.Unlock()


### PR DESCRIPTION
There are two issues in the vega-monitoring:

1. At some point comet transactions are not inserted into the postgresql.
2. Program memory usages increase a lot every few days.