### PR TITLE
feat: limit number of blocks for filter logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,14 @@ RPCEndpoint = "https://goerli.infura.io/v3/XXXXXXX" # infura daniel@vega.xyz
     ContractAddress = "0xB49281A7F7878Cdf5B6378d8c7dC211Ffc1b5B60"
     ABI = "[{\"anonymous\": false, \"inputs\": [{\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Disputed\", \"type\": \"event\"}, {\"anonymous\": false, \"inputs\": [{\"indexed\": false, \"internalType\": \"bool\", \"name\": \"result\", \"type\": \"bool\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, { \"indexed\": true,\"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Resolved\", \"type\": \"event\"}, {\"anonymous\": false, \"inputs\": [{\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Submitted\", \"type\": \"event\"}]"
     InitialBlocksToScan = 40 # ~half hour
+    MaxBlocksToFilter   = 1000
 
 [[Monitoring.EthereumChain.Events]]
     Name = "UMA Termination on Goerli"
     ContractAddress = "0x8744F73A5b404ef843A76A927dF89FE20ab071CB"
     ABI = "[{\"anonymous\": false, \"inputs\": [{\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Disputed\", \"type\": \"event\"}, {\"anonymous\": false, \"inputs\": [{\"indexed\": false, \"internalType\": \"bool\", \"name\": \"result\", \"type\": \"bool\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, { \"indexed\": true,\"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Resolved\", \"type\": \"event\"}, {\"anonymous\": false, \"inputs\": [{\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Submitted\", \"type\": \"event\"}]"
     InitialBlocksToScan = 40 # ~half hour
+    MaxBlocksToFilter   = 1000
 ```
 
 
@@ -240,12 +242,14 @@ vega_monitoring_contract_call_response{address="0x719AbD606155442c21b7d561426D42
     ContractAddress = "0xB49281A7F7878Cdf5B6378d8c7dC211Ffc1b5B60"
     ABI = "[{\"anonymous\": false, \"inputs\": [{\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Disputed\", \"type\": \"event\"}, {\"anonymous\": false, \"inputs\": [{\"indexed\": false, \"internalType\": \"bool\", \"name\": \"result\", \"type\": \"bool\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, { \"indexed\": true,\"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Resolved\", \"type\": \"event\"}, {\"anonymous\": false, \"inputs\": [{\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Submitted\", \"type\": \"event\"}]"
     InitialBlocksToScan = 40 # ~half hour
+    MaxBlocksToFilter   = 1000
 
 [[Monitoring.EthereumChain.Events]]
     Name = "UMA Termination on Goerli"
     ContractAddress = "0x8744F73A5b404ef843A76A927dF89FE20ab071CB"
     ABI = "[{\"anonymous\": false, \"inputs\": [{\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Disputed\", \"type\": \"event\"}, {\"anonymous\": false, \"inputs\": [{\"indexed\": false, \"internalType\": \"bool\", \"name\": \"result\", \"type\": \"bool\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, { \"indexed\": true,\"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Resolved\", \"type\": \"event\"}, {\"anonymous\": false, \"inputs\": [{\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"claimId\", \"type\": \"bytes32\"}, {\"indexed\": true, \"internalType\": \"bytes32\", \"name\": \"assertionId\", \"type\": \"bytes32\"}], \"name\": \"Submitted\", \"type\": \"event\"}]"
     InitialBlocksToScan = 40 # ~half hour
+    MaxBlocksToFilter   = 1000
 ```
 
 **Result:**

--- a/config/config.go
+++ b/config/config.go
@@ -169,6 +169,7 @@ type EthEvents struct {
 	ContractAddress     string `long:"ContractAddress"      comment:"Address of the ethereum contract you want to listen events on"`
 	ABI                 string `long:"ABI"                  comment:"ABI containing all the events you want to monitor as separated calls. Monitored event MUST be INDEXED, otherwise it cannot be deducted"`
 	InitialBlocksToScan uint64 `long:"InitialBlocksToScan"  comment:"Number of blocks to scan after vega-monitoring is started"`
+	MaxBlocksToFilter   uint64 `long:"MaxBlocksToFilter"    comment:"Number of blocks client may ask for when call FilterLogs"`
 }
 
 type EthCall struct {


### PR DESCRIPTION
# Issue

We had a following errors on one of the monitoring servers tonight:

```

May 01 21:34:10 m2.vega.community vega-monitoring[204155]: {"level":"error","@timestamp":"2024-05-01T21:34:10.319Z","logger":"root","caller":"ethereummonitoring/service.go:136","message":"Failed to filter logs for the events counter(UMA Termination on Arbitrum One): failed to run handler for 3 times, last error: failed to filter ethereum logs for contract 0x6d0b3a00265b8b4a1d22cf466c331014133ba614 for block <206821664; 206845974>: block range is too wide, all errors: [failed to filter ethereum logs for contract 0x6d0b3a00265b8b4a1d22cf466c331014133ba614 for block <206821664; 206845961>: block range is too wide failed to filter ethereum logs for contract 0x6d0b3a00265b8b4a1d22cf466c331014133ba614 for block <206821664; 206845972>: block range is too wide failed to filter ethereum logs for contract 0x6d0b3a00265b8b4a1d22cf466c331014133ba614 for block <206821664; 206845974>: block range is too wide]"}
May 01 21:34:55 m2.vega.community vega-monitoring[204155]: {"level":"info","@timestamp":"2024-05-01T21:34:55.784Z","logger":"root","caller":"config/config.go:201","message":"Reloaded config, because config file changed","event":"/home/vega/vega_monitoring_home/config.toml"}

```